### PR TITLE
feat: make aerender path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # automatic-videos
 Project for make automatic videos
+
+## Environment variables
+
+This project expects the path to After Effects' `aerender` executable to be
+available through the `AERENDER_PATH` environment variable.
+
+Example:
+
+```bash
+export AERENDER_PATH="C:/Program Files/Adobe/Adobe After Effects CC 2019/Support Files/aerender"
+npm run render
+```
+
+The `render` npm script sets a default value for Windows installations. Adjust
+the variable if After Effects is installed in a different location.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Project for make automatic videos",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "render": "set AERENDER_PATH=\"C:/Program Files/Adobe/Adobe After Effects CC 2019/Support Files/aerender\" && node index.js"
   },
   "repository": {
     "type": "git",

--- a/robots/video.js
+++ b/robots/video.js
@@ -1,3 +1,4 @@
+
 const gm = require('gm').subClass({imageMagick: true})
 const state = require('./state.js')
 const spawn = require('child_process').spawn
@@ -139,7 +140,10 @@ async function robot() {
 
     async function renderVideoWithAfterEffects() {
         return new Promise((resolve, reject) => {
-          const aerenderFilePath = 'C:/Program Files/Adobe/Adobe After Effects CC 2019/Support Files/aerender'
+          const aerenderFilePath = process.env.AERENDER_PATH
+          if (!aerenderFilePath) {
+            throw new Error('The AERENDER_PATH environment variable must be defined')
+          }
           const templateFilePath = `${rootPath}/templates/1/template.aep`
           const destinationFilePath = `${rootPath}/content/output.mov`
     


### PR DESCRIPTION
## Summary
- allow configuring After Effects path through `AERENDER_PATH`
- document `AERENDER_PATH` and add `render` npm script

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ac736b0fe8832085d3f9ab117f4371