### PR TITLE
Fix image conversion width and console output depth

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ async function start() {
     await robots.video()
 
     const content = robots.state.load()
-    console.dir(content, { depht: null })
+    console.dir(content, { depth: null })
 }
-
 start()

--- a/robots/video.js
+++ b/robots/video.js
@@ -24,7 +24,7 @@ async function robot() {
         return new Promise((resolve, reject) => {
             const inputFile = `./content/${sentenceIndex}--original.png[0]`
             const outputFile = `./content/${sentenceIndex}--converted.png`
-            const width = 1928
+            const width = 1920
             const height = 1080
 
         gm()


### PR DESCRIPTION
## Summary
- correct video image conversion width to 1920 for proper 1080p output
- use proper `depth` option in console output

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ac721661ac8320b55c3458f3f7c529