### PR TITLE
Fix Watson NLU error handling in text robot

### DIFF
--- a/robots/text.js
+++ b/robots/text.js
@@ -88,7 +88,7 @@ async function robot() {
                 }
             }, (error,response) => {
                 if (error) {
-                    throw error
+                    return reject(error)
                 }
     
                 const keywords = response.keywords.map((keyword) => {


### PR DESCRIPTION
## Summary
- handle Watson NLU analysis errors by rejecting the promise instead of throwing

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ac772373dc8320865c748297af6237