### PR TITLE
Handle prefix cancellation and cleanup input prompt

### DIFF
--- a/robots/input.js
+++ b/robots/input.js
@@ -10,15 +10,19 @@ function robot() {
     content.prefix = askAndReturnPrefix()
     state.save(content)
 
-    function askAndReturnSearchTerm(content) {
+    function askAndReturnSearchTerm() {
         return readline.question('Type a Wikipedia search term: ')
     }
 
-    function askAndReturnPrefix(content) {
+    function askAndReturnPrefix() {
         const prefixes = ['Who is', 'What is', 'The history of']
         const selectedPrefixIndex = readline.keyInSelect(prefixes, 'Choose one option: ')
+        if (selectedPrefixIndex === -1) {
+            console.log('No option selected, please choose one.')
+            return askAndReturnPrefix()
+        }
         const selectedPrefixText = prefixes[selectedPrefixIndex]
-    
+
         return selectedPrefixText
     }
 


### PR DESCRIPTION
## Summary
- remove unused `content` parameters in input robot helpers
- handle cancelled prefix selection by prompting again

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ac772623508320a9fdd002b8e6b85a