### PR TITLE
Handle missing keywords when fetching images

### DIFF
--- a/robots/image.js
+++ b/robots/image.js
@@ -14,10 +14,11 @@ async function robot() {
 
     async function fetchImagesOfAllSentences(content){
         for (const sentence of content.sentences) {
-            const query = `${content.searchTerm} ${sentence.keywords[0]}`
-                sentence.images = await fetchGoogleAndReturnImagesLinks(query)
+            const hasKeywords = sentence.keywords && sentence.keywords.length > 0
+            const searchTerm = hasKeywords ? `${content.searchTerm} ${sentence.keywords[0]}` : content.searchTerm
 
-                sentence.googleSearchQuery = query
+            sentence.images = await fetchGoogleAndReturnImagesLinks(searchTerm)
+            sentence.googleSearchQuery = searchTerm
         }
     }
 


### PR DESCRIPTION
## Summary
- Ensure sentences missing keywords still generate valid image search queries

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ac772973788320b4545734a924ef17