### PR TITLE
fix: standardize image conversion width

### DIFF
--- a/robots/video.js
+++ b/robots/video.js
@@ -25,7 +25,7 @@ async function robot() {
         return new Promise((resolve, reject) => {
             const inputFile = `./content/${sentenceIndex}--original.png[0]`
             const outputFile = `./content/${sentenceIndex}--converted.png`
-            const width = 1928
+            const width = 1920
             const height = 1080
 
         gm()


### PR DESCRIPTION
## Summary
- adjust image conversion width from 1928 to 1920 for standardized dimensions

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68ac772cd2088320a00bbef2faba1862